### PR TITLE
flight-reservation-fix: fix to retrieve flight reservations

### DIFF
--- a/flight/tests/test_flight.py
+++ b/flight/tests/test_flight.py
@@ -134,13 +134,19 @@ class ListCreateTestCase(APITestCase):
 
     def test_retrieve_reservations_any_valid_date_successful(self):
         """Verify all flight reservations for any existing valid date"""
-        date = {"date": self.flight_data["departure"].split(" ")[0]}
+        date = {
+            "date": self.flight.departure.split(" ")[0],
+            "flight_id": self.flight.id,
+        }
         response = self.client.get(self.reservations_url, data=date, format="json")
         self.assertEqual(response.status_code, HTTP_200_OK)
         self.assertEqual(response.data["reservations"], self.flight.number_booked)
 
     def test_retrieve_reservations_for_missing_date_unsuccessful(self):
-        """Verify that retrieval of flight reservations fails if no date is supplied"""
+        """
+        Verify that retrieval of flight reservations fails if no date and flight id
+        is supplied in the query params
+        """
         date = {}
         message = "please provide a date in the query param."
         response = self.client.get(self.reservations_url, data=date, format="json")
@@ -149,16 +155,19 @@ class ListCreateTestCase(APITestCase):
 
     def test_retrieve_reservations_for_invalid_date_format_unsuccessful(self):
         """Verify that retrieval of flight reservations fails if date format is invalid"""
-        date = {"date": "12-12-2019"}
+        date = {"date": "12-12-2019", "flight_id": self.flight.id}
         message = "Date has wrong format. Use this format YYYY-MM-DD."
         response = self.client.get(self.reservations_url, data=date, format="json")
         self.assertEqual(response.status_code, HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data["message"], message)
 
     def test_retrieve_reservations_for_invalid_date_unsuccessful(self):
-        """Verify that retrieval of flight reservations fails if date is invalid"""
-        date = {"date": "2019-12-12"}
-        message = "this departure date is invalid"
+        """
+        Verify that retrieval of flight reservations fails if date or flight id
+        supplied is invalid or do not match
+        """
+        date = {"date": "2019-12-12", "flight_id": self.flight.id}
+        message = "this departure date or flight_id is invalid or do not match"
         response = self.client.get(self.reservations_url, data=date, format="json")
         self.assertEqual(response.status_code, HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data["message"], message)

--- a/flight/views.py
+++ b/flight/views.py
@@ -70,6 +70,7 @@ class FlightListViewSet(
     @action(detail=False, methods=["GET"], permission_classes=[IsAdminUser])
     def reservations(self, request):
         date = request.query_params.get("date", None)
+        flight_id = request.query_params.get("flight_id", None)
         if date is None:
             return Response(
                 {"message": "please provide a date in the query param."},
@@ -83,13 +84,14 @@ class FlightListViewSet(
             )
 
         with connection.cursor() as cursor:
-            query = "SELECT number_booked FROM flight_flight WHERE Date(departure)=%s"
-            cursor.execute(query, [date])
+            query = "SELECT number_booked FROM flight_flight WHERE Date(departure)=%s AND id=%s"
+            cursor.execute(query, [date, flight_id])
             count_result = cursor.fetchall()
         if count_result:
             for item in count_result[0]:
                 result = item
             return Response({"reservations": result}, status=HTTP_200_OK)
         return Response(
-            {"message": "this departure date is invalid"}, status=HTTP_400_BAD_REQUEST
+            {"message": "this departure date or flight_id is invalid or do not match"},
+            status=HTTP_400_BAD_REQUEST,
         )


### PR DESCRIPTION
#### What does this PR do?
* It fixes to retrieve flight reservation count for a particular day for a specific flight.

#### How to test the PR?
* git fetch origin bug-fix-flight-reservation-count-#166200677
* git checkout bug-fix-flight-reservation-count-#166200677
* create `virtualenv` and cd into bookings
* use endpoint `http://127.0.0.1:8000/api/v1/flights/reservations?date={date}&flight_id={flight_id}` 